### PR TITLE
Allow passing custom notations

### DIFF
--- a/src/masked-text-changed-listener.ts
+++ b/src/masked-text-changed-listener.ts
@@ -8,11 +8,6 @@ import {MaskAffinity} from './helper/mask-affinity';
 import {InputEvent} from 'input-event';
 
 export class MaskedTextChangedListener {
-    protected readonly affineFormats: ReadonlyArray<String> = [];
-    protected readonly customNotations: ReadonlyArray<Notation> = [];
-    protected readonly affinityCalculationStrategy: AffinityCalculation =
-        new AffinityCalculation(AffinityCalculationStrategy.WHOLE_STRING);
-    protected readonly autocomplete: boolean = true;
     private readonly primaryMask = Mask.getOrCreate(this.primaryFormat, this.customNotations);
     private afterText: String = '';
     private caretPosition = 0;
@@ -21,11 +16,11 @@ export class MaskedTextChangedListener {
         protected readonly primaryFormat: String,
         private field: HTMLInputElement,
         protected readonly listener?: MaskedTextChangedListener.ValueListener,
-        affineFormats: ReadonlyArray<String> = [],
-        customNotations: ReadonlyArray<Notation> = [],
-        affinityCalculationStrategy: AffinityCalculation =
+        private affineFormats: ReadonlyArray<String> = [],
+        private customNotations: ReadonlyArray<Notation> = [],
+        private affinityCalculationStrategy: AffinityCalculation =
             new AffinityCalculation(AffinityCalculationStrategy.WHOLE_STRING),
-        autocomplete: boolean = true
+        protected autocomplete: boolean = true
     ) {
         this.affineFormats = affineFormats;
         this.customNotations = customNotations;


### PR DESCRIPTION
Hello,

I am using `input-mask-angular` which use your lib.
I just noticed that i am unable to pass custom option because they are ignored by your lib because of a strange typescript compilation: 

```
class MaskedTextChangedListener {
    constructor(primaryFormat, field, listener, affineFormats = [], customNotations = [], affinityCalculationStrategy = new affinity_calculation_strategy_1.AffinityCalculation(affinity_calculation_strategy_1.AffinityCalculationStrategy.WHOLE_STRING), autocomplete = true) {
        this.primaryFormat = primaryFormat;
        this.field = field;
        this.listener = listener;
        this.affineFormats = [];
        this.customNotations = [];

```

In this pull request i just replace field before constructor by field in the constructor using the default values.
I checked that all tests passed before pushing but i've not added additionnals tests.

Thanks